### PR TITLE
Fix theme naming inconsistencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,10 @@
 
 1. Open Visual Studio Code.
 2. Go to the **Extensions** view by clicking on the Extensions icon in the Activity Bar or by pressing `Ctrl+Shift+X`.
-3. Search for **"Soft Ivory Autumn Theme"**.
+3. Search for **"Autumn Breeze"**.
 4. Click **Install** to add the theme.
 5. Open the **Command Palette** (`Ctrl+Shift+P`) and type "Color Theme".
-6. Choose **Soft Ivory Autumn Theme** from the list of available themes.
+6. Choose **Autumn Breeze** from the list of available themes.
 
 ## 💻 Supported Languages
 

--- a/package.json
+++ b/package.json
@@ -43,5 +43,5 @@
     "type": "git",
     "url": "https://github.com/eduardodx/vscode-AutumnBreeze"
   },
-  "homepage": "https://github.com/your-username/vscode-AutumnBreeze#readme"
+  "homepage": "https://github.com/eduardodx/vscode-AutumnBreeze#readme"
 }

--- a/themes/autumn-breeze-light.json
+++ b/themes/autumn-breeze-light.json
@@ -1,5 +1,5 @@
 {
-  "name": "Soft Ivory Python Theme",
+  "name": "Autumn Breeze Light",
   "type": "light",
   "colors": {
     "editor.background": "#f8f5f1",


### PR DESCRIPTION
## Summary
- fix README install steps
- update theme name in light theme JSON
- correct homepage URL in `package.json`

## Testing
- `jq '.' themes/autumn-breeze-dark.json`
- `jq '.' themes/autumn-breeze-light.json`


------
https://chatgpt.com/codex/tasks/task_e_6841bd73ce00832781c6aeabfafe4b21